### PR TITLE
:sparkles: Extract family_type from FHIR when it exists

### DIFF
--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/Utils.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/Utils.scala
@@ -47,6 +47,7 @@ object Utils {
 
   val extractOfficial: Column => Column = (identifiers: Column) => coalesce(filter(identifiers, identifier => identifier("use") === "official")(0)("value"), identifiers(0)("value"))
 
+  val extractFirstSystemWithGivenSuffix: (Column, String) => Column = (column: Column, suffix: String) => filter(column, c=> c("system").endsWith(suffix))(0)
 
   val codingClassify: UserDefinedFunction =
     udf((arr: Seq[(String, String, String, String, String, String)]) =>

--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/package.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/package.scala
@@ -11,4 +11,5 @@ package object etl {
   val SYS_DATA_ACCESS_TYPES = "https://includedcc.org/fhir/code-systems/data_access_types"
   val SYS_YES_NO = "http://terminology.hl7.org/CodeSystem/v2-0136"
   val SYS_SHORT_CODE_KF = "https://kf-api-dataservice.kidsfirstdrc.org/studies?short_code="
+  val SYS_FAMILY_TYPE_INCLUDE = "https://includedcc.org/fhir/CodeSystem/data-dictionary/ABC-DS/participant/family_type"
 }

--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/package.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/package.scala
@@ -11,5 +11,5 @@ package object etl {
   val SYS_DATA_ACCESS_TYPES = "https://includedcc.org/fhir/code-systems/data_access_types"
   val SYS_YES_NO = "http://terminology.hl7.org/CodeSystem/v2-0136"
   val SYS_SHORT_CODE_KF = "https://kf-api-dataservice.kidsfirstdrc.org/studies?short_code="
-  val SYS_FAMILY_TYPE_INCLUDE = "https://includedcc.org/fhir/CodeSystem/data-dictionary/ABC-DS/participant/family_type"
+  val SYS_SUFFIX_FOR_FAMILY_TYPE_IN_INCLUDE = "/participant/family_type"
 }

--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/transformations/Transformations.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/transformations/Transformations.scala
@@ -230,6 +230,7 @@ object Transformations {
       .withColumn("exploded_member_entity", extractReferenceId(col("exploded_member")("entity")("reference")))
       .withColumn("exploded_member_inactive", col("exploded_member")("inactive"))
       .withColumn("family_members", struct("exploded_member_entity", "exploded_member_inactive"))
+      .withColumn("family_type_from_system", firstSystemEquals(col("code")("coding"), SYS_FAMILY_TYPE_INCLUDE)("display"))
       .groupBy("fhir_id", "study_id", "family_id", "external_id", "type", "release_id")
       .agg(
         collect_list("family_members") as "family_members",

--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/transformations/Transformations.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/transformations/Transformations.scala
@@ -230,7 +230,7 @@ object Transformations {
       .withColumn("exploded_member_entity", extractReferenceId(col("exploded_member")("entity")("reference")))
       .withColumn("exploded_member_inactive", col("exploded_member")("inactive"))
       .withColumn("family_members", struct("exploded_member_entity", "exploded_member_inactive"))
-      .withColumn("family_type_from_system", firstSystemEquals(col("code")("coding"), SYS_FAMILY_TYPE_INCLUDE)("display"))
+      .withColumn("family_type_from_system", extractFirstSystemWithGivenSuffix(col("code")("coding"), SYS_SUFFIX_FOR_FAMILY_TYPE_IN_INCLUDE)("display"))
       .groupBy("fhir_id", "study_id", "family_id", "external_id", "type", "release_id")
       .agg(
         collect_list("family_members") as "family_members",

--- a/prepare-index/src/main/scala/bio/ferlab/fhir/etl/common/Utils.scala
+++ b/prepare-index/src/main/scala/bio/ferlab/fhir/etl/common/Utils.scala
@@ -378,8 +378,7 @@ object Utils {
         )
         .withColumn("family_type",
           // lower to make sure that we match values from col("family_type_computation") (all lower case)
-          when(col("family_type_from_system").isNotNull, lower(col("family_type_from_system")))
-            .otherwise(col("family_type_computation"))
+          coalesce(lower(col("family_type_from_system")), col("family_type_computation"))
         )
         .withColumn("family", struct(
           filter(col("relations"), c => c("relation") === "father")(0)("related_participant_id") as "father_id",

--- a/prepare-index/src/test/scala/UtilsSpec.scala
+++ b/prepare-index/src/test/scala/UtilsSpec.scala
@@ -163,7 +163,7 @@ class UtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession {
     ).toDF()
 
     val inputFamilies = Seq(
-      GROUP(`fhir_id` = "111", `family_id` = "FM_111", `family_members` = Seq(("FTH", false), ("MTH", false), ("SON", false)), `family_members_id` = Seq("FTH", "MTH", "SON")),
+      GROUP(`fhir_id` = "111", `family_id` = "FM_111", `family_members` = Seq(("FTH", false), ("MTH", false), ("SON", false)), `family_members_id` = Seq("FTH", "MTH", "SON"), family_type_from_system = Some("Trio")),
       GROUP(`fhir_id` = "222", `family_id` = "FM_222", `family_members` = Seq(("44", false)), `family_members_id` = Seq("44"))
     ).toDF()
 

--- a/prepare-index/src/test/scala/model/GROUP.scala
+++ b/prepare-index/src/test/scala/model/GROUP.scala
@@ -6,7 +6,8 @@ case class GROUP(
                    family_id: String = "FM_NV901ZZN",
                    `type`: String = "person",
                    family_members: Seq[(String, Boolean)] = Seq(("38734", false)),
-                   family_members_id: Seq[String] = Seq("38734")
+                   family_members_id: Seq[String] = Seq("38734"),
+                   family_type_from_system: Option[String] = None
                  )
 case class FAMILY(
                    fhir_id: String = "42367",


### PR DESCRIPTION
family_type value can be extracted from INCLUDE FHIR directly instead of computing it. 

Here is an [example](https://include-api-fhir-service-qa.includedcc.org/Group/83344) of what it looks like at the time of this writing
```{
  "resourceType": "Group",
  "id": "83344",
  "meta": {
    "versionId": "1",
    "lastUpdated": "2023-05-10T17:57:49.159+00:00",
    "source": "#iMnJiMhBQXJuQria",
    "tag": [ {
      "system": ["https://includedcc.org/fhir/abc-ds/researchstudy"](https://includedcc.org/fhir/abc-ds/researchstudy),
      "code": "ABC-DS"
    } ]
  },
  "identifier": [ {
    "system": ["https://includedcc.org/fhir/abc-ds/group"](https://includedcc.org/fhir/abc-ds/group),
    "value": "ABC-DS.10043"
  }, {
    "use": "official",
    "system": ["https://includedcc.org/fhir/abc-ds/group/id"](https://includedcc.org/fhir/abc-ds/group/id),
    "value": "10043"
  } ],
  "type": "person",
  "actual": true,
  "code": {
    "coding": [ {
      "system": ["http://terminology.hl7.org/CodeSystem/v3-RoleCode"](http://terminology.hl7.org/CodeSystem/v3-RoleCode),
      "code": "FAMMEMB",
      "display": "family member"
    }, {
      "system": ["https://includedcc.org/fhir/CodeSystem/data-dictionary/ABC-DS/participant/family_type"](https://includedcc.org/fhir/CodeSystem/data-dictionary/ABC-DS/participant/family_type),
      "version": "v1",
      "code": "Other",
      "display": "Other" <======================== Extraction 
    } ]
  },
  "quantity": 2,
  "member": [ {
    "entity": {
      "reference": "Patient/pt-x6tdk3n69w"
    }
  }, {
    "entity": {
      "reference": "Patient/pt-dbmkfxpmnk"
    }
  } ]
}
```

Pls note that we have to use the computed version in KF at the moment.