### PR TITLE
:pencil: Use newly added family type system

### DIFF
--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/Utils.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/Utils.scala
@@ -47,8 +47,6 @@ object Utils {
 
   val extractOfficial: Column => Column = (identifiers: Column) => coalesce(filter(identifiers, identifier => identifier("use") === "official")(0)("value"), identifiers(0)("value"))
 
-  val extractFirstSystemWithGivenSuffix: (Column, String) => Column = (column: Column, suffix: String) => filter(column, c=> c("system").endsWith(suffix))(0)
-
   val codingClassify: UserDefinedFunction =
     udf((arr: Seq[(String, String, String, String, String, String)]) =>
       arr.map(

--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/package.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/package.scala
@@ -11,5 +11,5 @@ package object etl {
   val SYS_DATA_ACCESS_TYPES = "https://includedcc.org/fhir/code-systems/data_access_types"
   val SYS_YES_NO = "http://terminology.hl7.org/CodeSystem/v2-0136"
   val SYS_SHORT_CODE_KF = "https://kf-api-dataservice.kidsfirstdrc.org/studies?short_code="
-  val SYS_SUFFIX_FOR_FAMILY_TYPE_IN_INCLUDE = "/participant/family_type"
+  val SYS_FAMILY_TYPES = "https://includedcc.org/fhir/code-systems/family_types"
 }

--- a/import-task/src/main/scala/bio/ferlab/fhir/etl/transformations/Transformations.scala
+++ b/import-task/src/main/scala/bio/ferlab/fhir/etl/transformations/Transformations.scala
@@ -230,7 +230,7 @@ object Transformations {
       .withColumn("exploded_member_entity", extractReferenceId(col("exploded_member")("entity")("reference")))
       .withColumn("exploded_member_inactive", col("exploded_member")("inactive"))
       .withColumn("family_members", struct("exploded_member_entity", "exploded_member_inactive"))
-      .withColumn("family_type_from_system", extractFirstSystemWithGivenSuffix(col("code")("coding"), SYS_SUFFIX_FOR_FAMILY_TYPE_IN_INCLUDE)("display"))
+      .withColumn("family_type_from_system", firstSystemEquals(col("code")("coding"), SYS_FAMILY_TYPES)("display"))
       .groupBy("fhir_id", "study_id", "family_id", "external_id", "type", "release_id")
       .agg(
         collect_list("family_members") as "family_members",


### PR DESCRIPTION
After this conversation: https://teaminclude.slack.com/archives/C02CE3NNK7A/p1685039147786789?thread_ts=1684329370.464709&cid=C02CE3NNK7A

it s been decided that a more uniform system url will be used for family type