### PR TITLE
:recycle: Rename some diagnosis field (WIP)

### DIFF
--- a/etl/src/main/resources/templates/template_biospecimen_centric.json
+++ b/etl/src/main/resources/templates/template_biospecimen_centric.json
@@ -62,10 +62,19 @@
         "diagnosis_icd": {
           "type": "keyword"
         },
+        "icd_code": {
+          "type": "keyword"
+        },
         "diagnosis_mondo": {
           "type": "keyword"
         },
+        "mondo_code": {
+          "type": "keyword"
+        },
         "diagnosis_ncit": {
+          "type": "keyword"
+        },
+        "ncit_code": {
           "type": "keyword"
         },
         "external_collection_sample_id": {
@@ -321,13 +330,22 @@
                 "diagnosis_icd": {
                   "type": "keyword"
                 },
+                "icd_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_id": {
                   "type": "keyword"
                 },
                 "diagnosis_mondo": {
                   "type": "keyword"
                 },
+                "mondo_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_ncit": {
+                  "type": "keyword"
+                },
+                "ncit_code": {
                   "type": "keyword"
                 },
                 "fhir_id": {
@@ -336,13 +354,22 @@
                 "icd_id_diagnosis": {
                   "type": "keyword"
                 },
+                "icd_display_term": {
+                  "type": "keyword"
+                },
                 "mondo_id": {
                   "type": "keyword"
                 },
                 "mondo_id_diagnosis": {
                   "type": "keyword"
                 },
+                "mondo_display_term": {
+                  "type": "keyword"
+                },
                 "ncit_id_diagnosis": {
+                  "type": "keyword"
+                },
+                "ncit_display_term": {
                   "type": "keyword"
                 },
                 "source_text": {
@@ -710,6 +737,9 @@
               "type": "keyword"
             },
             "website": {
+              "type": "keyword"
+            },
+            "investigator_id": {
               "type": "keyword"
             }
           }

--- a/etl/src/main/resources/templates/template_biospecimen_centric.json
+++ b/etl/src/main/resources/templates/template_biospecimen_centric.json
@@ -357,9 +357,6 @@
                 "icd_display_term": {
                   "type": "keyword"
                 },
-                "mondo_id": {
-                  "type": "keyword"
-                },
                 "mondo_id_diagnosis": {
                   "type": "keyword"
                 },

--- a/etl/src/main/resources/templates/template_file_centric.json
+++ b/etl/src/main/resources/templates/template_file_centric.json
@@ -174,10 +174,19 @@
                 "diagnosis_icd": {
                   "type": "keyword"
                 },
+                "icd_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_mondo": {
                   "type": "keyword"
                 },
+                "mondo_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_ncit": {
+                  "type": "keyword"
+                },
+                "ncit_code": {
                   "type": "keyword"
                 },
                 "external_sample_id": {
@@ -273,13 +282,22 @@
                 "diagnosis_icd": {
                   "type": "keyword"
                 },
+                "icd_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_id": {
                   "type": "keyword"
                 },
                 "diagnosis_mondo": {
                   "type": "keyword"
                 },
+                "mondo_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_ncit": {
+                  "type": "keyword"
+                },
+                "ncit_code": {
                   "type": "keyword"
                 },
                 "fhir_id": {
@@ -288,13 +306,22 @@
                 "icd_id_diagnosis": {
                   "type": "keyword"
                 },
+                "icd_display_term": {
+                  "type": "keyword"
+                },
                 "mondo_id": {
                   "type": "keyword"
                 },
                 "mondo_id_diagnosis": {
                   "type": "keyword"
                 },
+                "mondo_display_term": {
+                  "type": "keyword"
+                },
                 "ncit_id_diagnosis": {
+                  "type": "keyword"
+                },
+                "ncit_display_term": {
                   "type": "keyword"
                 },
                 "source_text": {

--- a/etl/src/main/resources/templates/template_file_centric.json
+++ b/etl/src/main/resources/templates/template_file_centric.json
@@ -309,9 +309,6 @@
                 "icd_display_term": {
                   "type": "keyword"
                 },
-                "mondo_id": {
-                  "type": "keyword"
-                },
                 "mondo_id_diagnosis": {
                   "type": "keyword"
                 },

--- a/etl/src/main/resources/templates/template_participant_centric.json
+++ b/etl/src/main/resources/templates/template_participant_centric.json
@@ -36,13 +36,22 @@
             "diagnosis_icd": {
               "type": "keyword"
             },
+            "icd_code": {
+              "type": "keyword"
+            },
             "diagnosis_id": {
               "type": "keyword"
             },
             "diagnosis_mondo": {
               "type": "keyword"
             },
+            "mondo_code": {
+              "type": "keyword"
+            },
             "diagnosis_ncit": {
+              "type": "keyword"
+            },
+            "ncit_code": {
               "type": "keyword"
             },
             "fhir_id": {
@@ -51,13 +60,22 @@
             "icd_id_diagnosis": {
               "type": "keyword"
             },
+            "icd_display_term": {
+              "type": "keyword"
+            },
             "mondo_id": {
               "type": "keyword"
             },
             "mondo_id_diagnosis": {
               "type": "keyword"
             },
+            "mondo_display_term": {
+              "type": "keyword"
+            },
             "ncit_id_diagnosis": {
+              "type": "keyword"
+            },
+            "ncit_display_term": {
               "type": "keyword"
             },
             "source_text": {
@@ -168,10 +186,19 @@
                 "diagnosis_icd": {
                   "type": "keyword"
                 },
+                "icd_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_mondo": {
                   "type": "keyword"
                 },
+                "mondo_code": {
+                  "type": "keyword"
+                },
                 "diagnosis_ncit": {
+                  "type": "keyword"
+                },
+                "ncit_code": {
                   "type": "keyword"
                 },
                 "external_collection_sample_id": {
@@ -639,6 +666,9 @@
               "type": "keyword"
             },
             "website": {
+              "type": "keyword"
+            },
+            "investigator_id": {
               "type": "keyword"
             }
           }

--- a/etl/src/main/resources/templates/template_participant_centric.json
+++ b/etl/src/main/resources/templates/template_participant_centric.json
@@ -63,9 +63,6 @@
             "icd_display_term": {
               "type": "keyword"
             },
-            "mondo_id": {
-              "type": "keyword"
-            },
             "mondo_id_diagnosis": {
               "type": "keyword"
             },

--- a/etl/src/main/resources/templates/template_study_centric.json
+++ b/etl/src/main/resources/templates/template_study_centric.json
@@ -80,6 +80,9 @@
         },
         "website": {
           "type": "keyword"
+        },
+        "investigator_id": {
+          "type": "keyword"
         }
       }
     }

--- a/etl/src/main/scala/bio/ferlab/etl/Utils.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/Utils.scala
@@ -1,0 +1,9 @@
+package bio.ferlab.etl
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.{filter, lit, regexp_replace, trim}
+
+object Utils {
+  val firstCategory: (String, Column) => Column = (category, codes) => filter(codes, code => code("category") === lit(category))(0)("code")
+  val observableTitleStandard: Column => Column = term => trim(regexp_replace(term, "_", ":"))
+}

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
@@ -3,7 +3,6 @@ package bio.ferlab.etl.prepared.clinical
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
 import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
-import bio.ferlab.etl.prepared.clinical.OntologyUtils.firstCategory
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, lit, struct}
@@ -41,7 +40,9 @@ case class SimpleParticipant(rc: RuntimeETLContext, studyIds: List[String]) exte
                                lastRunDateTime: LocalDateTime = minDateTime,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val patientDF = data(normalized_patient.id)
-    val disease = data(normalized_disease.id).withColumn("mondo_id", observableTitleStandard(firstCategory("MONDO", col("condition_coding"))))
+    val disease = data(normalized_disease.id)
+      //FIXME: We may not need it. test one release without it to see if we really need it
+      // .withColumn("mondo_code", observableTitleStandard(firstCategory("MONDO", col("condition_coding"))))
     val transformedParticipant =
       patientDF
         .addStudy(data(es_index_study_centric.id))

--- a/etl/src/test/scala/bio/ferlab/etl/UtilsSpec.scala
+++ b/etl/src/test/scala/bio/ferlab/etl/UtilsSpec.scala
@@ -1,0 +1,22 @@
+package bio.ferlab.etl
+
+import bio.ferlab.datalake.testutils.WithSparkSession
+import bio.ferlab.etl.Utils.firstCategory
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.col
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class UtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession {
+
+  case class ConditionCoding(code: String, category: String)
+  import spark.implicits._
+
+  val SCHEMA_CONDITION_CODING = "array<struct<category:string,code:string>>"
+
+  "firstCategory" should "return the first found category" in {
+    val df = Seq(Seq(("ICD", "icd"))).toDF("condition_coding").withColumn("condition_coding", col("condition_coding").cast(SCHEMA_CONDITION_CODING))
+    df.withColumn("cat_icd", firstCategory("ICD", col("condition_coding"))).select("cat_icd").collect().head shouldBe Row("icd")
+    df.withColumn("cat_icd", firstCategory("NotFound", col("condition_coding"))).select("cat_icd").collect().head shouldBe Row(null)
+  }
+}

--- a/etl/src/test/scala/bio/ferlab/etl/prepared/clinical/OntologyUtilsSpec.scala
+++ b/etl/src/test/scala/bio/ferlab/etl/prepared/clinical/OntologyUtilsSpec.scala
@@ -1,7 +1,6 @@
 package bio.ferlab.etl.prepared.clinical
 
 import bio.ferlab.datalake.testutils.WithSparkSession
-import bio.ferlab.etl.prepared.clinical.OntologyUtils.firstCategory
 import bio.ferlab.etl.testmodels.normalized.AGE_AT_EVENT
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
@@ -22,7 +21,7 @@ class OntologyUtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession 
       ("part1", "diag1", "disease", Seq(("ICD", "icd")), Some("mondo"), AGE_AT_EVENT()),
       ("part1", "diag2", "disease", Seq(("ICD", "icd")), None, AGE_AT_EVENT()),
       ("part2", "diag3", "disease", Seq(("ICD", "icd")), None, AGE_AT_EVENT()),
-    ).toDF("participant_id", "diagnosis_id", "condition_profile", "condition_coding", "mondo_id", "age_at_event")
+    ).toDF("participant_id", "diagnosis_id", "condition_profile", "condition_coding", "mondo_code", "age_at_event")
       .withColumn("condition_coding", col("condition_coding").cast(SCHEMA_CONDITION_CODING))
 
     val mondoTerms = Seq(("mondo", "Mondo")).toDF("id", "name")
@@ -30,11 +29,5 @@ class OntologyUtilsSpec extends AnyFlatSpec with Matchers with WithSparkSession 
     val resultParticipant1 = result.filter(col("diagnosis_id") === "diag1").select("icd_id_diagnosis", "mondo_id_diagnosis").collect().head
 
     resultParticipant1 shouldBe Row("icd", "Mondo (mondo)")
-  }
-
-  "firstCategory" should "return the first found category" in {
-    val df = Seq(Seq(("ICD", "icd"))).toDF("condition_coding").withColumn("condition_coding", col("condition_coding").cast(SCHEMA_CONDITION_CODING))
-    df.withColumn("cat_icd", firstCategory("ICD", col("condition_coding"))).select("cat_icd").collect().head shouldBe Row("icd")
-    df.withColumn("cat_icd", firstCategory("NotFound", col("condition_coding"))).select("cat_icd").collect().head shouldBe Row(null)
   }
 }

--- a/etl/src/test/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipantSpec.scala
+++ b/etl/src/test/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipantSpec.scala
@@ -38,7 +38,7 @@ class SimpleParticipantSpec extends AnyFlatSpec with Matchers with WithSparkSess
       "normalized_disease" -> Seq(
         NORMALIZED_DISEASE(fhir_id = "CD1", participant_fhir_id = "P1", condition_coding = Seq(CONDITION_CODING(category = "ICD", code = "Q90.9"))),
         NORMALIZED_DISEASE(fhir_id = "CD2", participant_fhir_id = "P2", condition_coding = Seq(CONDITION_CODING(category = "ICD", code = "Q90.9"))),
-        NORMALIZED_DISEASE(fhir_id = "CD3", participant_fhir_id = "P1", condition_coding = Seq(CONDITION_CODING(category = "MONDO", code = "MONDO_0002028"))),
+        NORMALIZED_DISEASE(fhir_id = "CD3", participant_fhir_id = "P1", `mondo_code` = Some("MONDO:0002028"), condition_coding = Seq(CONDITION_CODING(category = "MONDO", code = "MONDO_0002028"))),
       ).toDF(),
       "normalized_group" -> Seq(
         NORMALIZED_GROUP(fhir_id = "G1", family_id = "G1", family_members = Seq(("P1", false), ("P2", false), ("P3", false)), family_members_id = Seq("P1", "P2", "P3")),

--- a/etl/src/test/scala/bio/ferlab/etl/prepared/clinical/UtilsSpec.scala
+++ b/etl/src/test/scala/bio/ferlab/etl/prepared/clinical/UtilsSpec.scala
@@ -134,11 +134,11 @@ class UtilsSpec extends AnyFlatSpec with Matchers with WithTestSimpleConfigurati
     ).toDF()
 
     val inputDiseases = Seq(
-      NORMALIZED_DISEASE(`fhir_id` = "O1", `participant_fhir_id` = "P1", `mondo_id` = Some("MONDO:0008608")),
-      NORMALIZED_DISEASE(`fhir_id` = "O2", `participant_fhir_id` = "P1", `mondo_id` = Some("MONDO:0008609")),
-      NORMALIZED_DISEASE(`fhir_id` = "O3", `participant_fhir_id` = "P2", `mondo_id` = Some("MONDO:0008609")),
-      NORMALIZED_DISEASE(`fhir_id` = "O4", `participant_fhir_id` = "P2", `mondo_id` = Some("MONDO:0000000")),
-      NORMALIZED_DISEASE(`fhir_id` = "O5", `participant_fhir_id` = "P3", `mondo_id` = Some("MONDO:0000000"))
+      NORMALIZED_DISEASE(`fhir_id` = "O1", `participant_fhir_id` = "P1", `mondo_code` = Some("MONDO:0008608")),
+      NORMALIZED_DISEASE(`fhir_id` = "O2", `participant_fhir_id` = "P1", `mondo_code` = Some("MONDO:0008609")),
+      NORMALIZED_DISEASE(`fhir_id` = "O3", `participant_fhir_id` = "P2", `mondo_code` = Some("MONDO:0008609")),
+      NORMALIZED_DISEASE(`fhir_id` = "O4", `participant_fhir_id` = "P2", `mondo_code` = Some("MONDO:0000000")),
+      NORMALIZED_DISEASE(`fhir_id` = "O5", `participant_fhir_id` = "P3", `mondo_code` = Some("MONDO:0000000"))
     ).toDF()
 
     val output = inputPatients.addDownSyndromeDiagnosis(inputDiseases, mondoTerms)
@@ -562,7 +562,7 @@ class UtilsSpec extends AnyFlatSpec with Matchers with WithTestSimpleConfigurati
         diagnosis_id = "diag1",
         participant_fhir_id = "A",
         condition_coding = Seq(CONDITION_CODING(`category` = "MONDO", `code` = "MONDO_0002051")),
-        mondo_id = Some("MONDO:0002051"),
+        mondo_code = Some("MONDO:0002051"),
         age_at_event = AGE_AT_EVENT(5),
       ),
       NORMALIZED_DISEASE(
@@ -570,7 +570,7 @@ class UtilsSpec extends AnyFlatSpec with Matchers with WithTestSimpleConfigurati
         diagnosis_id = "diag2",
         participant_fhir_id = "A",
         condition_coding = Seq(CONDITION_CODING(`category` = "MONDO", `code` = "MONDO_0024458")),
-        mondo_id = Some("MONDO:0024458"),
+        mondo_code = Some("MONDO:0024458"),
         age_at_event = AGE_AT_EVENT(10),
       ),
       NORMALIZED_DISEASE(fhir_id = "3d", diagnosis_id = "diag3", participant_fhir_id = "A")

--- a/etl/src/test/scala/bio/ferlab/etl/testmodels/normalized/NORMALIZED_DISEASE.scala
+++ b/etl/src/test/scala/bio/ferlab/etl/testmodels/normalized/NORMALIZED_DISEASE.scala
@@ -1,19 +1,19 @@
 package bio.ferlab.etl.testmodels.normalized
 
 case class NORMALIZED_DISEASE(
-                              `fhir_id`: String = "676049",
-                              `diagnosis_id`: String = "DG_KG6TQWCT",
-                              `condition_coding`: Seq[CONDITION_CODING] = Seq.empty[CONDITION_CODING],
-                              `source_text`: String = "Acute lymphoblastic leukemia",
-                              `participant_fhir_id`: String = "38722",
-                              `source_text_tumor_location`: Seq[String] = Seq.empty[String],
-                              `uberon_id_tumor_location`: Seq[String] = Seq.empty,
-                              `affected_status`: Boolean = false,
-                              `affected_status_text`: String = null,
-                              `mondo_id`: Option[String] = None,
-                              `age_at_event`: AGE_AT_EVENT = AGE_AT_EVENT(),
-                              `study_id`: String = "SD_Z6MWD3H0",
-                              `release_id`: String = "re_000001"
+                               `fhir_id`: String = "676049",
+                               `diagnosis_id`: String = "DG_KG6TQWCT",
+                               `condition_coding`: Seq[CONDITION_CODING] = Seq.empty[CONDITION_CODING],
+                               `source_text`: String = "Acute lymphoblastic leukemia",
+                               `participant_fhir_id`: String = "38722",
+                               `source_text_tumor_location`: Seq[String] = Seq.empty[String],
+                               `uberon_id_tumor_location`: Seq[String] = Seq.empty,
+                               `affected_status`: Boolean = false,
+                               `affected_status_text`: String = null,
+                               `mondo_code`: Option[String] = None,
+                               `age_at_event`: AGE_AT_EVENT = AGE_AT_EVENT(),
+                               `study_id`: String = "SD_Z6MWD3H0",
+                               `release_id`: String = "re_000001"
                             )
 
 case class CONDITION_CODING(


### PR DESCRIPTION
### Objectives

- Improve naming for diseases fields relating to MONDO, NCIT, ICD in order to diminish confusion;
- Avoid (if possible) adding an extra column (mondo_id) when extracting normalized data;
- Avoid repeating calculations and/or perform them as soon as possible in the steps

Note: fields were duplicated for 2 purposes: 1) to not break the portal(s) 2) to make the comparison easier. After tests, they will have to be cleanup.