### PR TITLE
feat: SJIP-617 add aggregated id biospecimen_id from container_id and sample_id

### DIFF
--- a/etl/src/main/resources/templates/template_biospecimen_centric.json
+++ b/etl/src/main/resources/templates/template_biospecimen_centric.json
@@ -40,6 +40,10 @@
             }
           }
         },
+        "biospecimen_id": {
+          "type": "keyword",
+          "normalizer": "custom_normalizer"
+        },
         "biospecimen_storage": {
           "type": "keyword"
         },

--- a/etl/src/main/resources/templates/template_file_centric.json
+++ b/etl/src/main/resources/templates/template_file_centric.json
@@ -156,6 +156,10 @@
                     }
                   }
                 },
+                "biospecimen_id": {
+                  "type": "keyword",
+                  "normalizer": "custom_normalizer"
+                },
                 "biospecimen_storage": {
                   "type": "keyword"
                 },

--- a/etl/src/main/resources/templates/template_participant_centric.json
+++ b/etl/src/main/resources/templates/template_participant_centric.json
@@ -162,6 +162,10 @@
                     }
                   }
                 },
+                "biospecimen_id": {
+                  "type": "keyword",
+                  "normalizer": "custom_normalizer"
+                },
                 "biospecimen_storage": {
                   "type": "keyword"
                 },

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/clinical/SpecimensTransformations.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/clinical/SpecimensTransformations.scala
@@ -4,7 +4,7 @@ import bio.ferlab.datalake.spark3.transformation.{Custom, Drop, Transformation}
 import bio.ferlab.etl.normalized.clinical.Utils._
 import bio.ferlab.etl.normalized.clinical.clinical._
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.{Column, DataFrame, functions}
 
 object SpecimensTransformations {
 
@@ -64,6 +64,8 @@ object SpecimensTransformations {
         .withColumn("ncit_id_tissue_type", extractNcitAnatomySiteId(col("type")("coding")))
         .withColumn("consent_type", extractConsentType("consent_type"))
         .withColumn("dbgap_consent_code", extractConsentType("dbgap_consent_code"))
+        .withColumn("biospecimen_id", functions.concat(coalesce(col("container_id"), lit("")), lit("__"), col("sample_id")))
+
 
       val grouped = addParentsToSpecimen(specimen)
         .groupBy("specimen.fhir_id", "specimen.container_id")


### PR DESCRIPTION
Pour avoir un ID unique pour les biospecimen autre que _id (qui change à chaque run de l'ETL)
Le combo container_id/sample_id est unique à travers toutes les études