### PR TITLE
feat: SKFP-793 use latest datalake-lib and drop column alternates after use

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import sbtassembly.AssemblyPlugin.autoImport.assembly
-val datalakeLibVersion = "10.5.0"
+val datalakeLibVersion = "12.0.2"
 
 lazy val fhavro_export = project in file("fhavro-export")
 

--- a/config/src/main/scala/bio/ferlab/fhir/etl/config/KFRuntimeETLContext.scala
+++ b/config/src/main/scala/bio/ferlab/fhir/etl/config/KFRuntimeETLContext.scala
@@ -1,13 +1,13 @@
 package bio.ferlab.fhir.etl.config
 
-import bio.ferlab.datalake.commons.config.BaseETLContext
+import bio.ferlab.datalake.commons.config.{RunStep, TimestampETLContext}
 import mainargs.{ParserForClass, arg}
 
 case class KFRuntimeETLContext(
                                 @arg(name = "config", short = 'c', doc = "Config path") path: String,
                                 @arg(name = "steps", short = 's', doc = "Steps") steps: String,
                                 @arg(name = "app-name", short = 'a', doc = "App name") appName: Option[String]
-                              ) extends BaseETLContext[ETLConfiguration](path, steps, appName) {
+                              ) extends TimestampETLContext[ETLConfiguration](path, RunStep.getSteps(steps) , appName) {
 
 }
 

--- a/etl/src/main/scala/bio/ferlab/etl/Utils.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/Utils.scala
@@ -3,10 +3,7 @@ package bio.ferlab.etl
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.{filter, lit, regexp_replace, trim}
 
-import java.time.LocalDateTime
-
 object Utils {
   val firstCategory: (String, Column) => Column = (category, codes) => filter(codes, code => code("category") === lit(category))(0)("code")
   val observableTitleStandard: Column => Column = term => trim(regexp_replace(term, "_", ":"))
-  val minDateTime: LocalDateTime = LocalDateTime.of(1900, 1, 1, 0, 0, 0)
 }

--- a/etl/src/main/scala/bio/ferlab/etl/Utils.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/Utils.scala
@@ -3,7 +3,10 @@ package bio.ferlab.etl
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.{filter, lit, regexp_replace, trim}
 
+import java.time.LocalDateTime
+
 object Utils {
   val firstCategory: (String, Column) => Column = (category, codes) => filter(codes, code => code("category") === lit(category))(0)("code")
   val observableTitleStandard: Column => Column = term => trim(regexp_replace(term, "_", ":"))
+  val minDateTime: LocalDateTime = LocalDateTime.of(1900, 1, 1, 0, 0, 0)
 }

--- a/etl/src/main/scala/bio/ferlab/etl/enriched/clinical/FamilyEnricher.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/enriched/clinical/FamilyEnricher.scala
@@ -1,7 +1,7 @@
 package bio.ferlab.etl.enriched.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._

--- a/etl/src/main/scala/bio/ferlab/etl/enriched/clinical/HistologyEnricher.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/enriched/clinical/HistologyEnricher.scala
@@ -1,7 +1,7 @@
 package bio.ferlab.etl.enriched.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.col

--- a/etl/src/main/scala/bio/ferlab/etl/enriched/clinical/SpecimenEnricher.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/enriched/clinical/SpecimenEnricher.scala
@@ -1,7 +1,7 @@
 package bio.ferlab.etl.enriched.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, functions}

--- a/etl/src/main/scala/bio/ferlab/etl/enriched/genomic/RunEnrichGenomic.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/enriched/genomic/RunEnrichGenomic.scala
@@ -22,10 +22,10 @@ object RunEnrichGenomic {
   }
 
   private def variants(rc: RuntimeETLContext) = Variants(rc, snvDatasetId = "normalized_snv",
-    frequencies = Seq(
+    splits = Seq(
       FrequencySplit(
         "studies",
-        splitBy = Some(col("study_id")), byAffected = false,
+        extraSplitBy = Some(col("study_id")), byAffected = false,
         extraAggregations = Seq(
           AtLeastNElements(name = "participant_ids", c = col("participant_id"), n = 10),
           SimpleAggregation(name = TRANSMISSIONS, c = col(TRANSMISSION_MODE)),

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/clinical/NormalizeClinicalETL.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/clinical/NormalizeClinicalETL.scala
@@ -1,7 +1,7 @@
 package bio.ferlab.etl.normalized.clinical
 
 import bio.ferlab.datalake.commons.config.DatasetConf
-import bio.ferlab.datalake.spark3.etl.v3.TransformationsETL
+import bio.ferlab.datalake.spark3.etl.v4.TransformationsETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
 import bio.ferlab.datalake.spark3.transformation.Transformation
 import bio.ferlab.fhir.etl.config.KFRuntimeETLContext

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/dataservice/DataserviceExportETL.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/dataservice/DataserviceExportETL.scala
@@ -1,7 +1,7 @@
 package bio.ferlab.etl.normalized.dataservice
 
 import bio.ferlab.datalake.commons.config.{Coalesce, DatasetConf}
-import bio.ferlab.datalake.spark3.etl.v3.ETL
+import bio.ferlab.datalake.spark3.etl.v4.ETL
 import bio.ferlab.etl.normalized.dataservice.model.{ESequencingCenter, ESequencingExperiment, ESequencingExperimentGenomicFile}
 import bio.ferlab.fhir.etl.config.KFRuntimeETLContext
 import org.apache.spark.sql.functions.lit

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/dataservice/EmptyDataserviceExportETL.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/dataservice/EmptyDataserviceExportETL.scala
@@ -1,8 +1,8 @@
 package bio.ferlab.etl.normalized.dataservice
 
 import bio.ferlab.datalake.commons.config.{Configuration, DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v2.ETL
-import bio.ferlab.datalake.spark3.etl.v3.SimpleETL
+import bio.ferlab.datalake.spark3.etl.v4.ETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleETL
 import bio.ferlab.etl.normalized.dataservice.model.{ESequencingCenter, ESequencingExperiment, ESequencingExperimentGenomicFile}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.{DataFrame, SparkSession}

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/Consequences.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/Consequences.scala
@@ -4,6 +4,7 @@ import bio.ferlab.datalake.commons.config.DatasetConf
 import bio.ferlab.datalake.spark3.genomics.normalized.BaseConsequences
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
 import bio.ferlab.datalake.spark3.implicits.GenomicImplicits.columns._
+import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.normalized.genomic.KFVCFUtils.loadVCFs
 import bio.ferlab.fhir.etl.config.StudyConfiguration.defaultStudyConfiguration
 import bio.ferlab.fhir.etl.config.{KFRuntimeETLContext, StudyConfiguration}

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/Consequences.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/Consequences.scala
@@ -18,7 +18,7 @@ case class Consequences(rc: KFRuntimeETLContext, studyId: String, referenceGenom
 
   private val studyConfiguration: StudyConfiguration = rc.config.studies.getOrElse(studyId, defaultStudyConfiguration)
 
-  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
+  override def extract(lastRunDateTime: LocalDateTime = minValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Map(
       raw_vcf -> loadVCFs(document_reference.read, studyConfiguration, studyId, referenceGenomePath)

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/Consequences.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/Consequences.scala
@@ -4,7 +4,6 @@ import bio.ferlab.datalake.commons.config.DatasetConf
 import bio.ferlab.datalake.spark3.genomics.normalized.BaseConsequences
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
 import bio.ferlab.datalake.spark3.implicits.GenomicImplicits.columns._
-import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.normalized.genomic.KFVCFUtils.loadVCFs
 import bio.ferlab.fhir.etl.config.StudyConfiguration.defaultStudyConfiguration
 import bio.ferlab.fhir.etl.config.{KFRuntimeETLContext, StudyConfiguration}
@@ -19,7 +18,7 @@ case class Consequences(rc: KFRuntimeETLContext, studyId: String, referenceGenom
 
   private val studyConfiguration: StudyConfiguration = rc.config.studies.getOrElse(studyId, defaultStudyConfiguration)
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
+  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Map(
       raw_vcf -> loadVCFs(document_reference.read, studyConfiguration, studyId, referenceGenomePath)

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/SNV.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/SNV.scala
@@ -21,7 +21,7 @@ case class SNV(rc:KFRuntimeETLContext, studyId: String, releaseId: String, refer
 
   private val studyConfiguration: StudyConfiguration = rc.config.studies.getOrElse(studyId, defaultStudyConfiguration)
 
-  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
+  override def extract(lastRunDateTime: LocalDateTime = minValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
 
     Map(

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/SNV.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/SNV.scala
@@ -6,7 +6,6 @@ import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
 import bio.ferlab.datalake.spark3.implicits.GenomicImplicits._
 import bio.ferlab.datalake.spark3.implicits.GenomicImplicits.columns._
 import bio.ferlab.etl.Constants.columns.{GENES_SYMBOL, TRANSMISSION_MODE}
-import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.normalized.genomic.KFVCFUtils.loadVCFs
 import bio.ferlab.fhir.etl.config.StudyConfiguration.defaultStudyConfiguration
 import bio.ferlab.fhir.etl.config.{KFRuntimeETLContext, StudyConfiguration}
@@ -22,7 +21,7 @@ case class SNV(rc:KFRuntimeETLContext, studyId: String, releaseId: String, refer
 
   private val studyConfiguration: StudyConfiguration = rc.config.studies.getOrElse(studyId, defaultStudyConfiguration)
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
+  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
 
     Map(

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/SNV.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/SNV.scala
@@ -1,17 +1,17 @@
 package bio.ferlab.etl.normalized.genomic
 
-import bio.ferlab.datalake.commons.config.{Configuration, DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.ETLSingleDestination
-import bio.ferlab.datalake.spark3.etl.v3.{SimpleSingleETL, SingleETL}
+import bio.ferlab.datalake.commons.config.DatasetConf
+import bio.ferlab.datalake.spark3.etl.v4.SingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
 import bio.ferlab.datalake.spark3.implicits.GenomicImplicits._
 import bio.ferlab.datalake.spark3.implicits.GenomicImplicits.columns._
 import bio.ferlab.etl.Constants.columns.{GENES_SYMBOL, TRANSMISSION_MODE}
+import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.normalized.genomic.KFVCFUtils.loadVCFs
-import bio.ferlab.fhir.etl.config.{KFRuntimeETLContext, StudyConfiguration}
 import bio.ferlab.fhir.etl.config.StudyConfiguration.defaultStudyConfiguration
+import bio.ferlab.fhir.etl.config.{KFRuntimeETLContext, StudyConfiguration}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{DataFrame, SparkSession, functions}
+import org.apache.spark.sql.{DataFrame, functions}
 
 import java.time.LocalDateTime
 
@@ -51,7 +51,7 @@ case class SNV(rc:KFRuntimeETLContext, studyId: String, releaseId: String, refer
       .withColumn("hgvsg", hgvsg)
       .withColumn("variant_class", variant_class)
       .withColumn(GENES_SYMBOL, array_distinct(annotations("symbol")))
-      .drop("annotation", "INFO_ANN")
+      .drop("annotation", "INFO_ANN", "alternates")
       .select(
         chromosome,
         start,

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/BiospecimenCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/BiospecimenCentric.scala
@@ -1,8 +1,9 @@
 package bio.ferlab.etl.prepared.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
+import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, struct}

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/BiospecimenCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/BiospecimenCentric.scala
@@ -21,7 +21,7 @@ case class BiospecimenCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   private val enriched_histology_disease: DatasetConf = conf.getDataset("enriched_histology_disease")
 
 
-  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
+  override def extract(lastRunDateTime: LocalDateTime = minValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
 
     Seq(normalized_specimen, normalized_drs_document_reference, simple_participant, es_index_study_centric,
@@ -32,7 +32,7 @@ case class BiospecimenCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
+                               lastRunDateTime: LocalDateTime = minValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val specimenDF = data(normalized_specimen.id)
     val filesWithSeqExp = data(normalized_drs_document_reference.id)

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/BiospecimenCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/BiospecimenCentric.scala
@@ -3,7 +3,6 @@ package bio.ferlab.etl.prepared.clinical
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
 import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
-import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, struct}
@@ -22,7 +21,7 @@ case class BiospecimenCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   private val enriched_histology_disease: DatasetConf = conf.getDataset("enriched_histology_disease")
 
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
+  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
 
     Seq(normalized_specimen, normalized_drs_document_reference, simple_participant, es_index_study_centric,
@@ -33,7 +32,7 @@ case class BiospecimenCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = minDateTime,
+                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val specimenDF = data(normalized_specimen.id)
     val filesWithSeqExp = data(normalized_drs_document_reference.id)

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/FileCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/FileCentric.scala
@@ -3,7 +3,6 @@ package bio.ferlab.etl.prepared.clinical
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
 import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
-import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, struct}
@@ -22,7 +21,7 @@ case class FileCentric(rc: RuntimeETLContext, studyIds: List[String]) extends Si
   val enriched_histology_disease: DatasetConf = conf.getDataset("enriched_histology_disease")
 
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
+  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Seq(
       normalized_drs_document_reference,
@@ -39,7 +38,7 @@ case class FileCentric(rc: RuntimeETLContext, studyIds: List[String]) extends Si
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = minDateTime,
+                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val fileDF = data(normalized_drs_document_reference.id)
 

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/FileCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/FileCentric.scala
@@ -1,8 +1,9 @@
 package bio.ferlab.etl.prepared.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
+import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, struct}

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/FileCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/FileCentric.scala
@@ -21,7 +21,7 @@ case class FileCentric(rc: RuntimeETLContext, studyIds: List[String]) extends Si
   val enriched_histology_disease: DatasetConf = conf.getDataset("enriched_histology_disease")
 
 
-  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
+  override def extract(lastRunDateTime: LocalDateTime = minValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Seq(
       normalized_drs_document_reference,
@@ -38,7 +38,7 @@ case class FileCentric(rc: RuntimeETLContext, studyIds: List[String]) extends Si
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
+                               lastRunDateTime: LocalDateTime = minValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val fileDF = data(normalized_drs_document_reference.id)
 

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/ParticipantCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/ParticipantCentric.scala
@@ -1,8 +1,9 @@
 package bio.ferlab.etl.prepared.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
+import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.col

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/ParticipantCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/ParticipantCentric.scala
@@ -20,7 +20,7 @@ case class ParticipantCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   private val enriched_histology_disease: DatasetConf = conf.getDataset("enriched_histology_disease")
 
 
-  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
+  override def extract(lastRunDateTime: LocalDateTime = minValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Seq(
       simple_participant,
@@ -36,7 +36,7 @@ case class ParticipantCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
+                               lastRunDateTime: LocalDateTime = minValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val patientDF = data(simple_participant.id)
     val filesWithSeqExp = data(normalized_drs_document_reference.id).addSequencingExperiment(data(normalized_sequencing_experiment.id), data(normalized_sequencing_experiment_genomic_file.id))

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/ParticipantCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/ParticipantCentric.scala
@@ -3,7 +3,6 @@ package bio.ferlab.etl.prepared.clinical
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
 import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
-import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.col
@@ -21,7 +20,7 @@ case class ParticipantCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   private val enriched_histology_disease: DatasetConf = conf.getDataset("enriched_histology_disease")
 
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
+  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Seq(
       simple_participant,
@@ -37,7 +36,7 @@ case class ParticipantCentric(rc: RuntimeETLContext, studyIds: List[String]) ext
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = minDateTime,
+                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val patientDF = data(simple_participant.id)
     val filesWithSeqExp = data(normalized_drs_document_reference.id).addSequencingExperiment(data(normalized_sequencing_experiment.id), data(normalized_sequencing_experiment_genomic_file.id))

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
@@ -1,8 +1,9 @@
 package bio.ferlab.etl.prepared.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
+import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, lit, struct}

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
@@ -23,7 +23,7 @@ case class SimpleParticipant(rc: RuntimeETLContext, studyIds: List[String]) exte
   val mondo_terms: DatasetConf = conf.getDataset("mondo_terms")
   val enriched_family: DatasetConf = conf.getDataset("enriched_family")
 
-  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
+  override def extract(lastRunDateTime: LocalDateTime = minValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     (Seq(
       es_index_study_centric, normalized_patient, normalized_phenotype, normalized_disease, normalized_group, normalized_vital_status, normalized_proband_observation, enriched_family)
@@ -37,7 +37,7 @@ case class SimpleParticipant(rc: RuntimeETLContext, studyIds: List[String]) exte
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
+                               lastRunDateTime: LocalDateTime = minValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val patientDF = data(normalized_patient.id)
     val disease = data(normalized_disease.id)

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/SimpleParticipant.scala
@@ -3,7 +3,6 @@ package bio.ferlab.etl.prepared.clinical
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
 import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits._
-import bio.ferlab.etl.Utils.minDateTime
 import bio.ferlab.etl.prepared.clinical.Utils._
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{col, lit, struct}
@@ -24,7 +23,7 @@ case class SimpleParticipant(rc: RuntimeETLContext, studyIds: List[String]) exte
   val mondo_terms: DatasetConf = conf.getDataset("mondo_terms")
   val enriched_family: DatasetConf = conf.getDataset("enriched_family")
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
+  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     (Seq(
       es_index_study_centric, normalized_patient, normalized_phenotype, normalized_disease, normalized_group, normalized_vital_status, normalized_proband_observation, enriched_family)
@@ -38,7 +37,7 @@ case class SimpleParticipant(rc: RuntimeETLContext, studyIds: List[String]) exte
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = minDateTime,
+                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val patientDF = data(normalized_patient.id)
     val disease = data(normalized_disease.id)

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/StudyCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/StudyCentric.scala
@@ -18,7 +18,7 @@ case class StudyCentric(rc: RuntimeETLContext, studyIds: List[String]) extends S
   val normalized_specimen: DatasetConf = conf.getDataset("normalized_specimen")
   val normalized_sequencing_experiment: DatasetConf = conf.getDataset("normalized_sequencing_experiment")
 
-  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
+  override def extract(lastRunDateTime: LocalDateTime = minValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Seq(
       normalized_researchstudy,
@@ -35,7 +35,7 @@ case class StudyCentric(rc: RuntimeETLContext, studyIds: List[String]) extends S
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
+                               lastRunDateTime: LocalDateTime = minValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val studyDF = data(normalized_researchstudy.id)
 

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/StudyCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/StudyCentric.scala
@@ -3,7 +3,6 @@ package bio.ferlab.etl.prepared.clinical
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
 import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
-import bio.ferlab.etl.Utils.minDateTime
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 
@@ -19,7 +18,7 @@ case class StudyCentric(rc: RuntimeETLContext, studyIds: List[String]) extends S
   val normalized_specimen: DatasetConf = conf.getDataset("normalized_specimen")
   val normalized_sequencing_experiment: DatasetConf = conf.getDataset("normalized_sequencing_experiment")
 
-  override def extract(lastRunDateTime: LocalDateTime = minDateTime,
+  override def extract(lastRunDateTime: LocalDateTime = rc.dataMinValue,
                        currentRunDateTime: LocalDateTime = LocalDateTime.now()): Map[String, DataFrame] = {
     Seq(
       normalized_researchstudy,
@@ -36,7 +35,7 @@ case class StudyCentric(rc: RuntimeETLContext, studyIds: List[String]) extends S
   }
 
   override def transformSingle(data: Map[String, DataFrame],
-                               lastRunDateTime: LocalDateTime = minDateTime,
+                               lastRunDateTime: LocalDateTime = rc.dataMinValue,
                                currentRunDateTime: LocalDateTime = LocalDateTime.now()): DataFrame = {
     val studyDF = data(normalized_researchstudy.id)
 

--- a/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/StudyCentric.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/prepared/clinical/StudyCentric.scala
@@ -1,8 +1,9 @@
 package bio.ferlab.etl.prepared.clinical
 
 import bio.ferlab.datalake.commons.config.{DatasetConf, RuntimeETLContext}
-import bio.ferlab.datalake.spark3.etl.v3.SimpleSingleETL
+import bio.ferlab.datalake.spark3.etl.v4.SimpleSingleETL
 import bio.ferlab.datalake.spark3.implicits.DatasetConfImplicits.DatasetConfOperations
+import bio.ferlab.etl.Utils.minDateTime
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 


### PR DESCRIPTION
I'm not 100% sure about what I did in : 

- KFRuntimeETLContext.scala
- RunEnrichGenomic.scala 
- Utils.scala (adding minDateTime since it's not in the lib anymore, is there another thing I should use in the lib instead ?)