### PR TITLE
fix: SKFP-986 fix for new VCF file to use Feature field for RefSeq or Feature depending on Source

### DIFF
--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/KFVCFUtils.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/KFVCFUtils.scala
@@ -186,7 +186,7 @@ object KFVCFUtils {
             csq("SYMBOL") as "SYMBOL",
             csq("Gene") as "Gene",
             csq("Feature_type") as "Feature_type",
-            csq("Feature") as "Feature",
+            when(csq("SOURCE") === "Ensembl", csq("Feature")).otherwise(lit(null)) as "Feature",
             csq("BIOTYPE") as "BIOTYPE",
             csq("EXON") as "EXON",
             csq("INTRON") as "INTRON",
@@ -208,7 +208,7 @@ object KFVCFUtils {
             csq("SIFT") as "SIFT",
             csq("HGVS_OFFSET") as "HGVS_OFFSET",
             csq("HGVSg") as "HGVSg",
-            csq("RefSeq") as "RefSeq",
+            when(csq("SOURCE") === "RefSeq", csq("Feature")).otherwise(csq("RefSeq")) as "RefSeq",
             csq("PUBMED") as "PUBMED",
             csq("PICK") as "PICK"
           )

--- a/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/KFVCFUtils.scala
+++ b/etl/src/main/scala/bio/ferlab/etl/normalized/genomic/KFVCFUtils.scala
@@ -186,7 +186,7 @@ object KFVCFUtils {
             csq("SYMBOL") as "SYMBOL",
             csq("Gene") as "Gene",
             csq("Feature_type") as "Feature_type",
-            when(csq("SOURCE") === "Ensembl", csq("Feature")).otherwise(lit(null)) as "Feature",
+            when(csq("SOURCE") === "RefSeq", lit(null)).otherwise(csq("Feature")) as "Feature",
             csq("BIOTYPE") as "BIOTYPE",
             csq("EXON") as "EXON",
             csq("INTRON") as "INTRON",


### PR DESCRIPTION
1) If Source = RefSeq then ensembl_transcript_id is empty and Feature will populate the refseq_mrna_id field 

if the RefSeq field also has values, prioritize the Feature field for refseq_mrna_id 

2) if Source = Ensembl then Feature will populate ensembl_transcript_id and the RefSeq column will populate the refseq_mrna_id field 